### PR TITLE
Support Ubunutu 20.04 which uses OpenCV 4 and PCL 1.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(file_player)
 
-add_definitions(-std=c++11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE release)
@@ -117,7 +118,6 @@ add_dependencies(file_player file_player_msgs_generate_messages_cpp ${PROJECT_NA
 add_dependencies(file_player ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(file_player
-
   ${catkin_LIBRARIES}
   ${QT_LIBRARIES} 
   ${OPENGL_LIBRARIES}

--- a/src/ROSThread.cpp
+++ b/src/ROSThread.cpp
@@ -1512,8 +1512,8 @@ void ROSThread::StereoThread()
         string current_stereo_right_name = data_folder_path_ + "/image/stereo_right" +"/"+ to_string(data)+".png";
         cv::Mat current_left_image;
         cv::Mat current_right_image;
-        current_left_image = imread(current_stereo_left_name, CV_LOAD_IMAGE_ANYDEPTH);
-        current_right_image = imread(current_stereo_right_name, CV_LOAD_IMAGE_ANYDEPTH);
+        current_left_image = imread(current_stereo_left_name, cv::IMREAD_ANYDEPTH);
+        current_right_image = imread(current_stereo_right_name, cv::IMREAD_ANYDEPTH);
 
         if(!current_left_image.empty() && !current_right_image.empty()){
 
@@ -1553,8 +1553,8 @@ void ROSThread::StereoThread()
           string next_stereo_right_name = data_folder_path_ + "/image/stereo_right" +"/"+ stereo_file_list_[current_img_index+1];
           cv::Mat next_left_image;
           cv::Mat next_right_image;
-          next_left_image = imread(next_stereo_left_name, CV_LOAD_IMAGE_ANYDEPTH);
-          next_right_image = imread(next_stereo_right_name, CV_LOAD_IMAGE_ANYDEPTH);
+          next_left_image = imread(next_stereo_left_name, cv::IMREAD_ANYDEPTH);
+          next_right_image = imread(next_stereo_right_name, cv::IMREAD_ANYDEPTH);
           if(!next_left_image.empty() && !next_right_image.empty()){
               stereo_left_next_img_ = make_pair(stereo_file_list_[current_img_index+1], next_left_image);
               stereo_right_next_img_ = make_pair(stereo_file_list_[current_img_index+1], next_right_image);
@@ -1647,11 +1647,11 @@ void ROSThread::OmniThread()
         cv::Mat omni2_image;
         cv::Mat omni3_image;
         cv::Mat omni4_image;
-        omni0_image = imread(current_omni0_name, CV_LOAD_IMAGE_COLOR);
-        omni1_image = imread(current_omni1_name, CV_LOAD_IMAGE_COLOR);
-        omni2_image = imread(current_omni2_name, CV_LOAD_IMAGE_COLOR);
-        omni3_image = imread(current_omni3_name, CV_LOAD_IMAGE_COLOR);
-        omni4_image = imread(current_omni4_name, CV_LOAD_IMAGE_COLOR);
+        omni0_image = imread(current_omni0_name, cv::IMREAD_COLOR);
+        omni1_image = imread(current_omni1_name, cv::IMREAD_COLOR);
+        omni2_image = imread(current_omni2_name, cv::IMREAD_COLOR);
+        omni3_image = imread(current_omni3_name, cv::IMREAD_COLOR);
+        omni4_image = imread(current_omni4_name, cv::IMREAD_COLOR);
         if(!omni0_image.empty() && !omni1_image.empty() && !omni2_image.empty() && !omni3_image.empty() && !omni4_image.empty()){
 
             cv::cvtColor(omni0_image, omni0_image, cv::COLOR_RGB2BGR);
@@ -1730,11 +1730,11 @@ void ROSThread::OmniThread()
           cv::Mat omni2_image;
           cv::Mat omni3_image;
           cv::Mat omni4_image;
-          omni0_image = imread(next_omni0_name, CV_LOAD_IMAGE_COLOR);
-          omni1_image = imread(next_omni1_name, CV_LOAD_IMAGE_COLOR);
-          omni2_image = imread(next_omni2_name, CV_LOAD_IMAGE_COLOR);
-          omni3_image = imread(next_omni3_name, CV_LOAD_IMAGE_COLOR);
-          omni4_image = imread(next_omni4_name, CV_LOAD_IMAGE_COLOR);
+          omni0_image = imread(next_omni0_name, cv::IMREAD_COLOR);
+          omni1_image = imread(next_omni1_name, cv::IMREAD_COLOR);
+          omni2_image = imread(next_omni2_name, cv::IMREAD_COLOR);
+          omni3_image = imread(next_omni3_name, cv::IMREAD_COLOR);
+          omni4_image = imread(next_omni4_name, cv::IMREAD_COLOR);
           if(!omni0_image.empty() && !omni1_image.empty() && !omni2_image.empty() && !omni3_image.empty() && !omni4_image.empty()){
               cv::cvtColor(omni0_image, omni0_image, cv::COLOR_RGB2BGR);
               cv::cvtColor(omni1_image, omni1_image, cv::COLOR_RGB2BGR);


### PR DESCRIPTION
This fixes two errors in trying to build on an Ubunutu 20.04 machine.
This is on ros noetic with opencv 4 and pcl 1.10.
Here are the two errors:

OpenCV 4 Errors:
```
Errors     << file_player:make /home/patrick/workspace/catkin_ws_ov/logs/file_player/build.make.005.log                                       
/home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.cpp: In member function ‘void ROSThread::StereoThread()’:
/home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.cpp:1515:63: error: ‘CV_LOAD_IMAGE_ANYDEPTH’ was not declared in this scope
 1515 |         current_left_image = imread(current_stereo_left_name, CV_LOAD_IMAGE_ANYDEPTH);
      |                                                               ^~~~~~~~~~~~~~~~~~~~~~
/home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.cpp:1556:59: error: ‘CV_LOAD_IMAGE_ANYDEPTH’ was not declared in this scope
 1556 |           next_left_image = imread(next_stereo_left_name, CV_LOAD_IMAGE_ANYDEPTH);
      |                                                           ^~~~~~~~~~~~~~~~~~~~~~
/home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.cpp: In member function ‘void ROSThread::OmniThread()’:
/home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.cpp:1650:50: error: ‘CV_LOAD_IMAGE_COLOR’ was not declared in this scope
 1650 |         omni0_image = imread(current_omni0_name, CV_LOAD_IMAGE_COLOR);
      |                                                  ^~~~~~~~~~~~~~~~~~~
/home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.cpp:1733:49: error: ‘CV_LOAD_IMAGE_COLOR’ was not declared in this scope
 1733 |           omni0_image = imread(next_omni0_name, CV_LOAD_IMAGE_COLOR);
      |                                                 ^~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/file_player.dir/build.make:104: CMakeFiles/file_player.dir/src/ROSThread.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:2549: CMakeFiles/file_player.dir/all] Error 2
make: *** [Makefile:141: all] Error 2

```


PCL Errors (small subset):
```
/usr/include/c++/9/bits/stl_algo.h:161:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)> >]’
/usr/include/c++/9/bits/stl_algo.h:3963:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)>]’
/usr/include/pcl-1.10/pcl/common/io.h:65:77:   required from here
/usr/include/c++/9/bits/predefined_ops.h:283:11: error: no match for call to ‘(pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)>) (const pcl::PCLPointField&)’
  283 |  { return bool(_M_pred(*__it)); }
      |           ^~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/pcl-1.10/pcl/io/file_io.h:41,
                 from /usr/include/pcl-1.10/pcl/io/pcd_io.h:44,
                 from /opt/ros/noetic/include/pcl_conversions/pcl_conversions.h:70,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.h:67,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/mainwindow.h:13,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/mainwindow.cpp:1:
/usr/include/pcl-1.10/pcl/common/io.h:65:9: note: candidate: ‘pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)>’
   65 |         [&field_name](const auto field) { return field.name == field_name; });
      |         ^
/usr/include/pcl-1.10/pcl/common/io.h:65:9: note:   no known conversion for argument 1 from ‘const pcl::PCLPointField’ to ‘int’
In file included from /usr/include/c++/9/bits/stl_algobase.h:71,
                 from /usr/include/c++/9/bits/char_traits.h:39,
                 from /usr/include/c++/9/ios:40,
                 from /usr/include/c++/9/ostream:38,
                 from /usr/include/c++/9/iostream:39,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/mainwindow.h:3,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/main.cpp:1:
/usr/include/c++/9/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_pred<_Predicate>::operator()(_Iterator) [with _Iterator = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = pcl::toPCLPointCloud2(const pcl::PCLPointCloud2&, pcl::PCLImage&)::<lambda(const int&)>]’:
/usr/include/c++/9/bits/stl_algo.h:120:14:   required from ‘_RandomAccessIterator std::__find_if(_RandomAccessIterator, _RandomAccessIterator, _Predicate, std::random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<pcl::toPCLPointCloud2(const pcl::PCLPointCloud2&, pcl::PCLImage&)::<lambda(const int&)> >]’
/usr/include/c++/9/bits/stl_algo.h:161:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<pcl::toPCLPointCloud2(const pcl::PCLPointCloud2&, pcl::PCLImage&)::<lambda(const int&)> >]’
/usr/include/c++/9/bits/stl_algo.h:3963:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = pcl::toPCLPointCloud2(const pcl::PCLPointCloud2&, pcl::PCLImage&)::<lambda(const int&)>]’
/usr/include/pcl-1.10/pcl/conversions.h:318:93:   required from here
/usr/include/c++/9/bits/predefined_ops.h:283:11: error: no match for call to ‘(pcl::toPCLPointCloud2(const pcl::PCLPointCloud2&, pcl::PCLImage&)::<lambda(const int&)>) (const pcl::PCLPointField&)’
  283 |  { return bool(_M_pred(*__it)); }
      |           ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/9/bits/predefined_ops.h:283:11: note: candidate: ‘void (*)(const int&)’ <conversion>
/usr/include/c++/9/bits/predefined_ops.h:283:11: note:   candidate expects 2 arguments, 2 provided
In file included from /opt/ros/noetic/include/pcl_conversions/pcl_conversions.h:44,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.h:67,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/mainwindow.h:13,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/main.cpp:1:
/usr/include/pcl-1.10/pcl/conversions.h:317:28: note: candidate: ‘pcl::toPCLPointCloud2(const pcl::PCLPointCloud2&, pcl::PCLImage&)::<lambda(const int&)>’
  317 |     const auto predicate = [](const auto& field) { return field.name == "rgb"; };
      |                            ^
/usr/include/pcl-1.10/pcl/conversions.h:317:28: note:   no known conversion for argument 1 from ‘const pcl::PCLPointField’ to ‘const int&’
In file included from /usr/include/c++/9/bits/stl_algobase.h:71,
                 from /usr/include/c++/9/bits/char_traits.h:39,
                 from /usr/include/c++/9/ios:40,
                 from /usr/include/c++/9/ostream:38,
                 from /usr/include/c++/9/iostream:39,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/mainwindow.h:3,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/main.cpp:1:
/usr/include/c++/9/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_pred<_Predicate>::operator()(_Iterator) [with _Iterator = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)>]’:
/usr/include/c++/9/bits/stl_algo.h:120:14:   required from ‘_RandomAccessIterator std::__find_if(_RandomAccessIterator, _RandomAccessIterator, _Predicate, std::random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)> >]’
/usr/include/c++/9/bits/stl_algo.h:161:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)> >]’
/usr/include/c++/9/bits/stl_algo.h:3963:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<const pcl::PCLPointField*, std::vector<pcl::PCLPointField> >; _Predicate = pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)>]’
/usr/include/pcl-1.10/pcl/common/io.h:65:77:   required from here
/usr/include/c++/9/bits/predefined_ops.h:283:11: error: no match for call to ‘(pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)>) (const pcl::PCLPointField&)’
  283 |  { return bool(_M_pred(*__it)); }
      |           ^~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/pcl-1.10/pcl/io/file_io.h:41,
                 from /usr/include/pcl-1.10/pcl/io/pcd_io.h:44,
                 from /opt/ros/noetic/include/pcl_conversions/pcl_conversions.h:70,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/ROSThread.h:67,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/mainwindow.h:13,
                 from /home/patrick/workspace/catkin_ws_ov/src/file_player/src/main.cpp:1:
/usr/include/pcl-1.10/pcl/common/io.h:65:9: note: candidate: ‘pcl::getFieldIndex(const pcl::PCLPointCloud2&, const string&)::<lambda(int)>’
   65 |         [&field_name](const auto field) { return field.name == field_name; });
      |         ^
/usr/include/pcl-1.10/pcl/common/io.h:65:9: note:   no known conversion for argument 1 from ‘const pcl::PCLPointField’ to ‘int’
make[2]: *** [CMakeFiles/file_player.dir/build.make:78: CMakeFiles/file_player.dir/file_player_autogen/mocs_compilation.cpp.o] Error 1
make[2]: *** [CMakeFiles/file_player.dir/build.make:91: CMakeFiles/file_player.dir/src/mainwindow.cpp.o] Error 1
make[2]: *** [CMakeFiles/file_player.dir/build.make:117: CMakeFiles/file_player.dir/src/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2549: CMakeFiles/file_player.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```